### PR TITLE
Feature unfollow author

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -48,7 +48,17 @@ router.post("/login", (req, res) => {
 });
 
 router.get("/user_details", authenticate, (req, res) => {
-  const user = _.pick(req.user, ["username", "email"]);
+  const user = _.pick(
+    req.user,
+    "email",
+    "username",
+    "photo",
+    "bio",
+    "followedAuthors",
+    "followers",
+    "_id"
+  );
+  console.log(user);
   res.send(user);
 });
 

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -1,11 +1,13 @@
 import axios from "axios";
 import setError from "./error";
 import setActionStatus from "./status";
+import { setDetails } from "./profile";
 
-export const setUserDetails = ({ username, email, token }) => ({
+export const setUserDetails = ({ username, email, id, token }) => ({
   type: "SET_DETAILS",
   username,
   email,
+  id,
   token
 });
 
@@ -48,15 +50,16 @@ export const tokenAuthentication = token => {
     return axios({ url, method: "get", headers: { token } })
       .then(response => {
         const data = response.data;
+        console.log(data);
         dispatch(setActionStatus("SUCCESSFUL"));
 
         dispatch(
           setUserDetails({
-            username: data.username,
-            email: data.email,
+            ...data,
             token
           })
         );
+        dispatch(setDetails(data));
         dispatch(setError(""));
       })
       .catch(error => {

--- a/src/actions/profile.js
+++ b/src/actions/profile.js
@@ -87,12 +87,10 @@ export const followUnfollowAuthor = (author, token, type) => {
       data: author
     })
       .then(res => {
-        console.log(res);
         dispatch(setActionStatus("SUCCESSFUL"));
         dispatch(setDetails(res.data));
       })
       .catch(err => {
-        console.log(err);
         dispatch(setActionStatus("FAILED"));
       });
   };

--- a/src/actions/profile.js
+++ b/src/actions/profile.js
@@ -2,11 +2,12 @@ import axios from "axios";
 import setError from "./error";
 import setActionStatus from "./status";
 
-export const setDetails = ({ bio, photo, username }) => ({
+export const setDetails = ({ bio, photo, followedAuthors, followers }) => ({
   type: "SET_PROFILE_DETAILS",
   bio,
   photo,
-  username
+  followedAuthors,
+  followers
 });
 
 export const createProfile = (details, token) => {
@@ -72,19 +73,27 @@ export const getProfile = username => {
   };
 };
 
-export const followAuthor = (author, token) => {
+export const followUnfollowAuthor = (author, token, type) => {
   return dispatch => {
-    console.log(author);
-    const url = `${process.env.API_URL}auth/follow/`;
+    const url = `${process.env.API_URL}auth/${
+      type === "follow" ? "follow" : "unfollow"
+    }/`;
     return axios({
       url,
-      method: "patch",
+      method: type === "follow" ? "patch" : "delete",
       headers: {
         token
       },
       data: author
     })
-      .then(res => console.log(res))
-      .catch(err => console.log(err));
+      .then(res => {
+        console.log(res);
+        dispatch(setActionStatus("SUCCESSFUL"));
+        dispatch(setDetails(res.data));
+      })
+      .catch(err => {
+        console.log(err);
+        dispatch(setActionStatus("FAILED"));
+      });
   };
 };

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -5,7 +5,8 @@ export default (state = { username: "", email: "" }, action) => {
         ...state,
         username: action.username,
         email: action.email,
-        token: action.token
+        token: action.token,
+        id: action.id
       };
     case "CLEAR_DETAILS":
       return { ...state, username: "", email: "", token: "" };

--- a/src/reducers/profile.js
+++ b/src/reducers/profile.js
@@ -4,7 +4,9 @@ export default (state = {}, action) => {
       return {
         ...state,
         photo: action.photo,
-        bio: action.bio
+        bio: action.bio,
+        followedAuthors: action.followedAuthors,
+        followers: action.followers
       };
     case "CLEAR_PROFILE_DETAILS":
       return {};


### PR DESCRIPTION
Created a server-side route for unfollowing users, and edited `followAuthor` action to make it a multi-purpose action that follows or unfollows an author based on the `type` argument it receives. Edited the `auth` reducer to add the `_id` field for the current user to state, and the `profile` reducer to keep the `followedAuthors` and `followers` properties for authenticated users in state