### PR TITLE
Fix errors in `onChange` handlers

### DIFF
--- a/src/components/CreateProfile.jsx
+++ b/src/components/CreateProfile.jsx
@@ -19,7 +19,7 @@ class CreateProfile extends Component {
       photo,
       errors: {
         ...prevState.errors,
-        photo
+        photo: ""
       }
     }));
   };
@@ -30,7 +30,7 @@ class CreateProfile extends Component {
       bio,
       errors: {
         ...prevState.errors,
-        bio
+        bio: ""
       }
     }));
   };


### PR DESCRIPTION
Fix errors in the `onChange` handlers of `CreateProfile` that resulted in the values of `state.photo` and `state.bio` being displayed as errors when the `photo` and `bio` fields are updated