### PR TITLE
Fix errors in `onChange` handlers

### DIFF
--- a/src/components/CreateProfile.jsx
+++ b/src/components/CreateProfile.jsx
@@ -19,7 +19,7 @@ class CreateProfile extends Component {
       photo,
       errors: {
         ...prevState.errors,
-        photo
+        photo: ""
       }
     }));
   };
@@ -30,7 +30,7 @@ class CreateProfile extends Component {
       bio,
       errors: {
         ...prevState.errors,
-        bio
+        bio: ""
       }
     }));
   };


### PR DESCRIPTION
Fix an error in the `onChange` handlers in the `CreateProfile` that result in the values from the text fields being displayed as errors on the form